### PR TITLE
Remove unused Moq package reference

### DIFF
--- a/test/Autofac.Extras.CommonServiceLocator.Test/Autofac.Extras.CommonServiceLocator.Test.csproj
+++ b/test/Autofac.Extras.CommonServiceLocator.Test/Autofac.Extras.CommonServiceLocator.Test.csproj
@@ -27,7 +27,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
+
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- Remove unused Moq package reference from test project
- Part of cross-repo effort to standardize on NSubstitute

## Test plan
- [x] `dotnet build` passes
- [x] All 13 tests pass