### PR TITLE
Remove obsolete AppVeyor VersionPrefix from csproj

### DIFF
--- a/src/Autofac.Extras.CommonServiceLocator/Autofac.Extras.CommonServiceLocator.csproj
+++ b/src/Autofac.Extras.CommonServiceLocator/Autofac.Extras.CommonServiceLocator.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- VersionPrefix patched by AppVeyor -->
-    <VersionPrefix>0.0.1</VersionPrefix>
     <!-- Assembly metadata -->
     <AssemblyName>Autofac.Extras.CommonServiceLocator</AssemblyName>
     <Description>Autofac extension for using the Microsoft Enterprise Library Common Service Locator with Autofac.</Description>


### PR DESCRIPTION
## Summary
- Removes the `<VersionPrefix>` property and associated AppVeyor comment from the source .csproj
- Version is set by `default.proj` via `/p:Version` during GitHub Actions CI, making the csproj entry unnecessary
- Eliminates risk of accidentally building with a dummy `0.0.1` version outside the normal pipeline

## Test plan
- [ ] CI build passes (version still correctly set by default.proj)
- [ ] Verify produced package has correct version suffix based on branch