### PR TITLE
Technology refresh: update dependencies and target frameworks

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
-    <Version>6.1.0</Version>
+    <Version>7.0.0</Version>
     <SolutionName>Autofac.Extras.CommonServiceLocator</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Extras.CommonServiceLocator/Autofac.Extras.CommonServiceLocator.csproj
+++ b/src/Autofac.Extras.CommonServiceLocator/Autofac.Extras.CommonServiceLocator.csproj
@@ -11,7 +11,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.1;netstandard2.0;</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -56,12 +56,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.5.0" />
+    <PackageReference Include="Autofac" Version="9.1.0" />
     <PackageReference Include="CommonServiceLocator" Version="2.0.7" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Update target frameworks from net7.0;net6.0 to net10.0;net8.0
- Update Autofac from 6.5.0 to 9.1.0
- Update Microsoft.SourceLink.GitHub from 1.1.1 to 10.0.300
- Update StyleCop.Analyzers from 1.2.0-beta.435 to 1.2.0-beta.556
- Bump version from 6.1.0 to 7.0.0 (major version bump due to Autofac update)

## Test plan

- [x] Build succeeds with zero warnings
- [x] All tests pass (13/13 passed on net10.0)
- [x] Pre-commit hooks pass