### PR TITLE
Update dependencies (Autofac 9.3.1)

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <!-- Increment the overall semantic version here. -->
-    <Version>7.0.0</Version>
+    <Version>7.0.1</Version>
     <SolutionName>Autofac.Extras.CommonServiceLocator</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Extras.CommonServiceLocator/Autofac.Extras.CommonServiceLocator.csproj
+++ b/src/Autofac.Extras.CommonServiceLocator/Autofac.Extras.CommonServiceLocator.csproj
@@ -53,12 +53,12 @@
     <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.3.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="CommonServiceLocator" Version="2.0.7" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Extras.CommonServiceLocator.Test/Autofac.Extras.CommonServiceLocator.Test.csproj
+++ b/test/Autofac.Extras.CommonServiceLocator.Test/Autofac.Extras.CommonServiceLocator.Test.csproj
@@ -29,8 +29,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- Autofac `9.3.0` -> `9.3.1` (src — shipping dependency)
- SonarAnalyzer.CSharp `10.27.0.140913` -> `10.28.0.143324` (src + test — analyzer, private assets)
- Microsoft.NET.Test.Sdk `18.6.0` -> `18.7.0` (test only)
- Package version bumped `7.0.0` -> `7.0.1`

## Test plan

- [ ] CI build passes (compile + test all target frameworks)
- [ ] No new warnings or errors introduced